### PR TITLE
Add ModMenu library badge on Fabric

### DIFF
--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -17,5 +17,10 @@
   "depends": {
     "fabric": "*",
     "minecraft": ">=1.21-beta.4"
+  },
+  "custom": {
+    "modmenu": {
+      "badges": ["library"]
+    }
   }
 }


### PR DESCRIPTION
This tells ModMenu that the mod is a library and so fixes the mod being shown in the menu even when the user wants library mods hidden.