### PR TITLE
feat: delegating delegates to allow for cool stuff

### DIFF
--- a/common/src/main/kotlin/com/teamresourceful/resourcefulconfigkt/api/ConfigKt.kt
+++ b/common/src/main/kotlin/com/teamresourceful/resourcefulconfigkt/api/ConfigKt.kt
@@ -11,7 +11,7 @@ import org.jetbrains.annotations.Range
 import java.util.function.UnaryOperator
 
 open class ConfigKt(
-    @Pattern("^[a-z0-9_/-]+$") private val file: String
+    @Pattern("^[a-z0-9_/-]+$") private val file: String,
 ) : CategoryBuilder(file) {
 
     private var registered: Boolean = false
@@ -20,7 +20,13 @@ open class ConfigKt(
     open val patches: Map<Int, UnaryOperator<JsonObject>> = mapOf()
 
     override fun build(parent: ResourcefulConfig?): ResourcefulConfig {
-        val config = ParsedConfig(this.version, this.file, ConfigKtInfo(this), this.elements, LinkedHashMap<String, ResourcefulConfig>())
+        val config = ParsedConfig(
+            this.version,
+            this.file,
+            ConfigKtInfo(this),
+            this.elements,
+            LinkedHashMap<String, ResourcefulConfig>()
+        )
         for ((id, builder) in this.categories) {
             config.categories[id] = builder.build(config)
         }

--- a/common/src/main/kotlin/com/teamresourceful/resourcefulconfigkt/api/Entries.kt
+++ b/common/src/main/kotlin/com/teamresourceful/resourcefulconfigkt/api/Entries.kt
@@ -11,12 +11,13 @@ import kotlin.reflect.KProperty
 class EntryDelegate<T> internal constructor(
     private val default: T,
     private var value: T,
-) {
+) : RConfigKtEntry<T> {
 
-    internal var onChange: (T, T) -> Unit = { _, _ -> }
+    override var onChange: (T, T) -> Unit = { _, _ -> }
+    override val parent: EntryDelegate<T> = this
 
-    operator fun getValue(thisRef: Any?, property: Any?): T = get()
-    operator fun setValue(thisRef: Any?, property: Any?, value: T) = set(value)
+    override operator fun getValue(thisRef: Any?, property: Any?): T = get()
+    override operator fun setValue(thisRef: Any?, property: Any?, value: T) = set(value)
 
     fun get(): T {
         return value
@@ -37,24 +38,21 @@ class EntryDelegate<T> internal constructor(
 }
 
 class TransformedEntryDelegate<T, R> internal constructor(
-    private val parent: EntryDelegate<T>,
+    val actualParent: RConfigKtEntry<T>,
     private val from: (R) -> T,
     private val to: (T) -> R,
-) {
+) : RConfigKtEntry<R> {
 
-    private var value: R = to(parent.get())
+    override val parent: RConfigKtEntry<R> = this
 
-    init {
-        parent.onChange = { old, new ->
-            value = to(new)
+    override var onChange: (R, R) -> Unit
+        get() = { p1, p2 -> actualParent.onChange(from(p1), from(p2)) }
+        set(value) {
+            actualParent.onChange = { p1, p2 -> value(to(p1), to(p2))}
         }
-    }
 
-    operator fun getValue(thisRef: Any?, property: Any?): R = value
-    operator fun setValue(thisRef: Any?, property: Any?, value: R) {
-        parent.set(from(value))
-        this.value = value
-    }
+    override operator fun getValue(thisRef: Any?, property: Any?): R = to(actualParent.getValue(thisRef, property))
+    override operator fun setValue(thisRef: Any?, property: Any?, value: R) = actualParent.setValue(thisRef, property, from(value))
 }
 
 class Entry<T, B : TypeBuilder> internal constructor(
@@ -63,60 +61,71 @@ class Entry<T, B : TypeBuilder> internal constructor(
     private val builderFactory: (String) -> B,
     private val builderFiller: (B) -> Unit,
     private val value: T,
-) {
+) : ConfigDelegateProvider<RConfigKtEntry<T>> {
 
-    operator fun provideDelegate(builder: EntriesBuilder, prop: KProperty<*>): EntryDelegate<T> {
+    override operator fun provideDelegate(entries: EntriesBuilder, prop: KProperty<*>): EntryDelegate<T> {
         val id = id ?: prop.name
         val entryBuilder = builderFactory(id).apply(builderFiller)
-        var data = entryBuilder.toEntryData()
+        val data = entryBuilder.toEntryData()
         val property = EntryDelegate<T>(this.value, this.value)
 
-        builder.element(EntryElementKt(
-            id,
-            entryBuilder,
-            KotlinConfigEntry<Any>(
-                type,
-                { property.set(it as T) },
-                { property.get() as Any },
-                data,
-                value as Any
+        entries.element(
+            EntryElementKt(
+                id,
+                entryBuilder,
+                KotlinConfigEntry<Any>(
+                    type,
+                    { property.set(it as T) },
+                    { property.get() as Any },
+                    data,
+                    value as Any
+                )
             )
-        ))
+        )
         return property
     }
 }
 
-class ObservableEntry<T, B : TypeBuilder>(
-    private val entry: Entry<T, B>,
-    private val onChange: (T, T) -> Unit
-) {
-    operator fun provideDelegate(builder: EntriesBuilder, prop: KProperty<*>): EntryDelegate<T> {
-        val property = entry.provideDelegate(builder, prop)
+class ObservableEntry<T>(
+    private val entry: ConfigDelegateProvider<RConfigKtEntry<T>>,
+    private val onChange: (T, T) -> Unit,
+) : ConfigDelegateProvider<RConfigKtEntry<T>> {
+    override operator fun provideDelegate(entries: EntriesBuilder, prop: KProperty<*>): RConfigKtEntry<T> {
+        val property = entry.provideDelegate(entries, prop)
         property.onChange = onChange
         return property
     }
 }
 
-class TransformedEntry<T, B : TypeBuilder, R>(
-    private val entry: Entry<T, B>,
+class TransformedEntry<T, R>(
+    private val entry: ConfigDelegateProvider<RConfigKtEntry<T>>,
     private val from: (R) -> T,
     private val to: (T) -> R,
-) {
-    operator fun provideDelegate(builder: EntriesBuilder, prop: KProperty<*>): TransformedEntryDelegate<T, R> {
-        val property = entry.provideDelegate(builder, prop)
-        return TransformedEntryDelegate(property, from, to)
+) : ConfigDelegateProvider<RConfigKtEntry<R>> {
+    override operator fun provideDelegate(entries: EntriesBuilder, prop: KProperty<*>): RConfigKtEntry<R> {
+        val property = entry.provideDelegate(entries, prop)
+        return TransformedEntryDelegate(property.parent, from, to)
     }
 }
 
 class ObjectProperty<T : ObjectKt>(
     val instance: T,
-    val factory: TypeBuilder.() -> Unit = {}
+    val factory: TypeBuilder.() -> Unit = {},
 ) {
-
     operator fun provideDelegate(entries: EntriesBuilder, prop: KProperty<*>): Lazy<T> {
         val builder = TypeBuilder(prop.name).apply(factory)
         entries.element(ObjectEntryElementKt(prop.name, builder, instance.build(builder.toEntryData())))
         return lazyOf(instance)
     }
+}
 
+interface RConfigKtEntry<T> {
+    val parent: RConfigKtEntry<T>
+    var onChange: (T, T) -> Unit
+    operator fun getValue(thisRef: Any?, property: Any?): T
+    operator fun setValue(thisRef: Any?, property: Any?, value: T)
+}
+
+interface ConfigDelegateProvider<D> {
+    operator fun provideDelegate(entries: EntriesBuilder, prop: KProperty<*>): D
 }

--- a/common/src/main/kotlin/com/teamresourceful/resourcefulconfigkt/api/Entries.kt
+++ b/common/src/main/kotlin/com/teamresourceful/resourcefulconfigkt/api/Entries.kt
@@ -8,22 +8,24 @@ import com.teamresourceful.resourcefulconfigkt.impl.EntryElementKt
 import com.teamresourceful.resourcefulconfigkt.impl.ObjectEntryElementKt
 import kotlin.reflect.KProperty
 
-class EntryDelegate<T> internal constructor(
+class EntryDelegate<T> internal constructor(entry: RConfigKtEntry<T>): RConfigKtEntry<T> by entry
+
+class EntryDelegateImpl<T> internal constructor(
     private val default: T,
     private var value: T,
 ) : RConfigKtEntry<T> {
 
     override var onChange: (T, T) -> Unit = { _, _ -> }
-    override val parent: EntryDelegate<T> = this
+    override val parent: EntryDelegateImpl<T> = this
 
     override operator fun getValue(thisRef: Any?, property: Any?): T = get()
     override operator fun setValue(thisRef: Any?, property: Any?, value: T) = set(value)
 
-    fun get(): T {
+    override fun get(): T {
         return value
     }
 
-    fun set(newValue: T) {
+    override fun set(newValue: T) {
         val oldValue = this.value
         this.value = newValue
 
@@ -32,7 +34,7 @@ class EntryDelegate<T> internal constructor(
         }
     }
 
-    fun reset() {
+    override fun reset() {
         this.value = default
     }
 }
@@ -51,6 +53,10 @@ class TransformedEntryDelegate<T, R> internal constructor(
             actualParent.onChange = { p1, p2 -> value(to(p1), to(p2))}
         }
 
+    override fun get(): R = to(actualParent.get())
+    override fun set(newValue: R) = actualParent.set(from(newValue))
+    override fun reset() = actualParent.reset()
+
     override operator fun getValue(thisRef: Any?, property: Any?): R = to(actualParent.getValue(thisRef, property))
     override operator fun setValue(thisRef: Any?, property: Any?, value: R) = actualParent.setValue(thisRef, property, from(value))
 }
@@ -67,7 +73,7 @@ class Entry<T, B : TypeBuilder> internal constructor(
         val id = id ?: prop.name
         val entryBuilder = builderFactory(id).apply(builderFiller)
         val data = entryBuilder.toEntryData()
-        val property = EntryDelegate<T>(this.value, this.value)
+        val property = EntryDelegateImpl<T>(this.value, this.value)
 
         entries.element(
             EntryElementKt(
@@ -82,7 +88,7 @@ class Entry<T, B : TypeBuilder> internal constructor(
                 )
             )
         )
-        return property
+        return EntryDelegate(property)
     }
 }
 
@@ -90,10 +96,10 @@ class ObservableEntry<T>(
     private val entry: ConfigDelegateProvider<RConfigKtEntry<T>>,
     private val onChange: (T, T) -> Unit,
 ) : ConfigDelegateProvider<RConfigKtEntry<T>> {
-    override operator fun provideDelegate(entries: EntriesBuilder, prop: KProperty<*>): RConfigKtEntry<T> {
+    override operator fun provideDelegate(entries: EntriesBuilder, prop: KProperty<*>): EntryDelegate<T> {
         val property = entry.provideDelegate(entries, prop)
         property.onChange = onChange
-        return property
+        return EntryDelegate(property)
     }
 }
 
@@ -102,7 +108,7 @@ class TransformedEntry<T, R>(
     private val from: (R) -> T,
     private val to: (T) -> R,
 ) : ConfigDelegateProvider<RConfigKtEntry<R>> {
-    override operator fun provideDelegate(entries: EntriesBuilder, prop: KProperty<*>): RConfigKtEntry<R> {
+    override operator fun provideDelegate(entries: EntriesBuilder, prop: KProperty<*>): TransformedEntryDelegate<T, R> {
         val property = entry.provideDelegate(entries, prop)
         return TransformedEntryDelegate(property.parent, from, to)
     }
@@ -122,6 +128,11 @@ class ObjectProperty<T : ObjectKt>(
 interface RConfigKtEntry<T> {
     val parent: RConfigKtEntry<T>
     var onChange: (T, T) -> Unit
+
+    fun get(): T
+    fun set(newValue: T)
+    fun reset()
+
     operator fun getValue(thisRef: Any?, property: Any?): T
     operator fun setValue(thisRef: Any?, property: Any?, value: T)
 }

--- a/common/src/main/kotlin/com/teamresourceful/resourcefulconfigkt/api/builders/EntriesBuilder.kt
+++ b/common/src/main/kotlin/com/teamresourceful/resourcefulconfigkt/api/builders/EntriesBuilder.kt
@@ -95,7 +95,9 @@ open class EntriesBuilder {
     fun <T : Enum<T>> draggable(vararg value: T, builder: DraggableBuilder<T>.() -> Unit = {}) = Entry(null, EntryType.ENUM, { DraggableBuilder(it, getEmptyArray<T>(value.javaClass)) }, builder, value)
     fun <T : Enum<T>> draggable(id: String, vararg value: T, builder: DraggableBuilder<T>.() -> Unit = {}) = Entry(id, EntryType.ENUM, { DraggableBuilder(it, getEmptyArray<T>(value.javaClass)) }, builder, value)
 
+    fun <T> observable(entry: Entry<T, *>, onChange: (T, T) -> Unit) = ObservableEntry(entry, onChange)
     fun <T> observable(entry: ConfigDelegateProvider<RConfigKtEntry<T>>, onChange: (T, T) -> Unit) = ObservableEntry(entry, onChange)
+    fun <T, R> transform(entry: Entry<T, *>, from: (R) -> T, to: (T) -> R) = TransformedEntry(entry, from, to)
     fun <T, R> transform(entry: ConfigDelegateProvider<RConfigKtEntry<T>>, from: (R) -> T, to: (T) -> R) = TransformedEntry(entry, from, to)
 
     companion object {

--- a/common/src/main/kotlin/com/teamresourceful/resourcefulconfigkt/api/builders/EntriesBuilder.kt
+++ b/common/src/main/kotlin/com/teamresourceful/resourcefulconfigkt/api/builders/EntriesBuilder.kt
@@ -6,8 +6,8 @@ import com.teamresourceful.resourcefulconfig.api.types.options.EntryType
 import com.teamresourceful.resourcefulconfig.api.types.options.TranslatableValue
 import com.teamresourceful.resourcefulconfigkt.api.ConfigDelegateProvider
 import com.teamresourceful.resourcefulconfigkt.api.Entry
-import com.teamresourceful.resourcefulconfigkt.api.ObservableEntry
 import com.teamresourceful.resourcefulconfigkt.api.RConfigKtEntry
+import com.teamresourceful.resourcefulconfigkt.api.ObservableEntry
 import com.teamresourceful.resourcefulconfigkt.api.TransformedEntry
 
 open class EntriesBuilder {

--- a/common/src/main/kotlin/com/teamresourceful/resourcefulconfigkt/api/builders/EntriesBuilder.kt
+++ b/common/src/main/kotlin/com/teamresourceful/resourcefulconfigkt/api/builders/EntriesBuilder.kt
@@ -4,8 +4,10 @@ import com.teamresourceful.resourcefulconfig.api.types.ResourcefulConfigElement
 import com.teamresourceful.resourcefulconfig.api.types.elements.ResourcefulConfigEntryElement
 import com.teamresourceful.resourcefulconfig.api.types.options.EntryType
 import com.teamresourceful.resourcefulconfig.api.types.options.TranslatableValue
+import com.teamresourceful.resourcefulconfigkt.api.ConfigDelegateProvider
 import com.teamresourceful.resourcefulconfigkt.api.Entry
 import com.teamresourceful.resourcefulconfigkt.api.ObservableEntry
+import com.teamresourceful.resourcefulconfigkt.api.RConfigKtEntry
 import com.teamresourceful.resourcefulconfigkt.api.TransformedEntry
 
 open class EntriesBuilder {
@@ -93,8 +95,8 @@ open class EntriesBuilder {
     fun <T : Enum<T>> draggable(vararg value: T, builder: DraggableBuilder<T>.() -> Unit = {}) = Entry(null, EntryType.ENUM, { DraggableBuilder(it, getEmptyArray<T>(value.javaClass)) }, builder, value)
     fun <T : Enum<T>> draggable(id: String, vararg value: T, builder: DraggableBuilder<T>.() -> Unit = {}) = Entry(id, EntryType.ENUM, { DraggableBuilder(it, getEmptyArray<T>(value.javaClass)) }, builder, value)
 
-    fun <T, B : TypeBuilder> observable(entry: Entry<T, B>, onChange: (T, T) -> Unit) = ObservableEntry(entry, onChange)
-    fun <T, B : TypeBuilder, R> transform(entry: Entry<T, B>, from: (R) -> T, to: (T) -> R) = TransformedEntry(entry, from, to)
+    fun <T> observable(entry: ConfigDelegateProvider<RConfigKtEntry<T>>, onChange: (T, T) -> Unit) = ObservableEntry(entry, onChange)
+    fun <T, R> transform(entry: ConfigDelegateProvider<RConfigKtEntry<T>>, from: (R) -> T, to: (T) -> R) = TransformedEntry(entry, from, to)
 
     companion object {
 


### PR DESCRIPTION
This is useful so you can add your own `transform` or `observable` like methods, while still keeping the functionality of all other methods, making them chainable :3